### PR TITLE
onaction: allow recursion

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function sendAction (options) {
     if (typeof action === 'object') params = action
     else if (typeof action === 'string') params = extend({ type: action }, params)
 
-    var newState = options.onaction(params, state)
+    var newState = options.onaction(params, state, send)
     update(params, newState)
   }
 


### PR DESCRIPTION
I tend to separate my `onaction` calls into `effects` and `reducers`. `reducers` are synchronous actions that only update state. `effects` are asynchronous actions that eventually return and emit another action.

In order to make this workflow possible, it's necessary to make `send` available in the `onaction` call. At the moment I'm passing references between scopes to enable this, but having the argument be passed directly would remove the need for boilerplate.

I hope this is reasonable enough. Thanks!
