### PR TITLE
Entire newstate

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ module.exports = function sendAction (options) {
     if (typeof action === 'object') params = action
     else if (typeof action === 'string') params = extend({ type: action }, params)
 
-    var newState = options.onaction(params, state, send)
-    update(params, newState)
+    var stateUpdates = options.onaction(params, state, send)
+    update(params, stateUpdates)
   }
 
-  function update (params, newState) {
+  function update (params, stateUpdates) {
     var oldState = state
-    state = extend(state, newState)
-    options.onchange(params, newState, oldState)
+    state = extend(state, stateUpdates)
+    options.onchange(params, state, oldState)
   }
 
   send.event = function sendAction_event (action, params, flag) {

--- a/test.js
+++ b/test.js
@@ -64,3 +64,21 @@ test('get state', function (t) {
   send({ type: 'example', example: false })
   t.end()
 })
+
+test('onchange returns entire newState', function (t) {
+  var send = sendAction({
+    state: {
+      a: 123,
+      b: 456
+    },
+    onaction: function modifier (action, state) {
+      return { b: action.value }
+    },
+    onchange: function (params, newState, oldState) {
+      t.ok(newState.a, 'state has no property "a"')
+    }
+  })
+
+  send({ value: 789 })
+  t.end()
+})


### PR DESCRIPTION
Since `onaction` only requires you to send the state updates, and not the full new state (like redux would), `onchange` has the potential to only receive these state updates instead of the entire new state. This pull request ensures that `onchange` always receives the entire new state, and I renamed `newState` to `stateUpdates` to more accurately reflect what send-action expects from (and does with) the `onaction` callback.

Here's a [demonstration](http://requirebin.com/?gist=206c310fa91cf3a47a92bfa6f5fe6cb1) of the current (pre-pull request) functionality.
