### PR TITLE
send: fix possible race conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,18 @@ module.exports = function sendAction (options) {
   var state = options.state || {}
 
   function send (action, params) {
-    if (typeof action === 'object') params = action
-    else if (typeof action === 'string') params = extend({ type: action }, params)
+    process.nextTick(function () {
+      if (typeof action === 'object') {
+        params = action
+      } else if (typeof action === 'string') {
+        params = extend({ type: action }, params)
+      }
 
-    var stateUpdates = options.onaction(params, state, send)
-    if (state !== stateUpdates) {
-      update(params, stateUpdates)
-    }
+      var stateUpdates = options.onaction(params, state, send)
+      if (state !== stateUpdates) {
+        update(params, stateUpdates)
+      }
+    })
   }
 
   function update (params, stateUpdates) {


### PR DESCRIPTION
When calling nested `send()`s, possible race conditions might occur if
the update happens in the same tick. This patch makes it so that
`send()` is guaranteed to run on the next tick. Thanks!
